### PR TITLE
Convert example accountstore_settings.yaml to a code block in documen…

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -14,15 +14,12 @@ YOSAI_ALCHEMYSTORE_SETTINGS=/path/to/your/accountstore_settings.yaml
 
 Again, Yosai uses sqlite as the backend for AlchemyAccountStore for integrated testing.  The accountstore_settings.yaml is simply:
 
-<--------------- cut below this line
----
-ENGINE_CONFIG: 
-    dialect:  sqlite
-    path: '//'
-    userid:
-    password:
-    hostname:
-    port:
-    db:
----------------> cut above this line
+    ENGINE_CONFIG: 
+        dialect:  sqlite
+        path: '//'
+        userid:
+        password:
+        hostname:
+        port:
+        db:
 


### PR DESCRIPTION
…tation

The example accountstore_settings.yaml was not readable because it wasn't in a code block so everything was running into one line. Placing it in a code block made it much more readable. Also no longer needed the cut lines