### PR TITLE
pytest-capurelog not right, should be pytest-catchlog

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 To run the tests you need to install additional requirements:
     pip install pytest
-    pip install pytest-capturelog
+    pip install pytest-catchlog
 
 Tests are categorized as integrated and isolated (unit).  
 


### PR DESCRIPTION
pytest-catchlog is a fork of pytest-capturelog, one of the changes is that pytest-catchlog makes the text method a property. If you use pytest-capturelog tests will fail with TypeError: argument of type 'method' is not iterable