### PR TITLE
Fixed log that used a variable that does not exist

### DIFF
--- a/yosai/core/authz/authz.py
+++ b/yosai/core/authz/authz.py
@@ -425,7 +425,7 @@ class ModularRealmAuthorizer(authz_abcs.Authorizer):
                 realm.clear_cached_authorization_info(identifier)
         except AttributeError:
             msg = ('Could not clear authc_info from cache after event. '
-                   'identifiers: ' + identifiers)
+                   'identifiers: ' + identifier)
             logger.warn(msg)
 
     def register_cache_clear_listener(self):


### PR DESCRIPTION
"Could not clear authc_info from cache" error had the variable as `identifiers` instead of `identifier` which lead to a `NameError`, when there's no cache